### PR TITLE
SSM agent should be enabled by default.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -83,5 +83,5 @@ default['ssm_agent'].tap do |config|
   # Actions to set the agent to
   # * Note: We set this to disable / start to provide faster boot times
   # @since 0.1.0
-  config['service']['actions'] = %w(disable start)
+  # config['service']['actions'] = %w(disable start)
 end


### PR DESCRIPTION
Disabling the agent may provide faster boot up times but also completely negates the purpose of installing the agent.

This should be a commented out option and not the recipe default.