### PR TITLE
Support for Snap Packages

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 
 default['ssm_agent'].tap do |config|
+  config['install_method'] = 'package'
+
   # Attempt to detect the current region from Ohai
   # @since 0.1.0
   if node['ec2'] && node['ec2']['region'] # Chef 13+

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Amazon EC2 Simple Systems Manager (SSM) agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/sturdycloud/sturdy_ssm_agent-cookbook/issues'
 source_url 'https://github.com/sturdycloud/sturdy_ssm_agent-cookbook'
-version '2.1.1'
+version '2.1.2'
 
 chef_version '>= 12.1' if respond_to?(:chef_version)
 %w(amazon redhat debian ubuntu suse).each do |p|

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Amazon EC2 Simple Systems Manager (SSM) agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/sturdycloud/sturdy_ssm_agent-cookbook/issues'
 source_url 'https://github.com/sturdycloud/sturdy_ssm_agent-cookbook'
-version '2.0.0'
+version '2.1.0'
 
 chef_version '>= 12.1' if respond_to?(:chef_version)
 %w(amazon redhat debian ubuntu suse).each do |p|

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Amazon EC2 Simple Systems Manager (SSM) agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/sturdycloud/sturdy_ssm_agent-cookbook/issues'
 source_url 'https://github.com/sturdycloud/sturdy_ssm_agent-cookbook'
-version '2.1.0'
+version '2.1.1'
 
 chef_version '>= 12.1' if respond_to?(:chef_version)
 %w(amazon redhat debian ubuntu suse).each do |p|

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,5 +17,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include_recipe "#{cookbook_name}::install"
+include_recipe "#{cookbook_name}::install_#{node['ssm_agent']['install_method']}"
 include_recipe "#{cookbook_name}::logrotate"

--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook:: sturdy_ssm_agent
-# Recipe:: install
+# Recipe:: install_package
 #
 # Copyright:: 2017, Sturdy Networks
 # Copyright:: 2017, Jonathan Serafini
@@ -16,6 +16,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+if Dir.exist?('/snap/amazon-ssm-agent')
+  execute 'snap remove amazon-ssm-agent'
+end
 
 # Download the installer
 # @since 0.1.0

--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -41,6 +41,7 @@ package 'amazon-ssm-agent' do # ~FC109
     'debian' => Chef::Provider::Package::Dpkg,
     'windows' => Chef::Provider::Package::Windows
   )
+  action :upgrade
 end
 
 # Ensure service state

--- a/recipes/install_snap.rb
+++ b/recipes/install_snap.rb
@@ -1,0 +1,29 @@
+#
+# Cookbook:: sturdy_ssm_agent
+# Recipe:: install_snap
+#
+# Copyright:: 2018, Arvato Systems
+# Copyright:: 2018, Patrick Robinson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package 'amazon-ssm-agent' do
+  action :remove
+end
+
+execute 'snap install amazon-ssm-agent --classic'
+
+execute 'snap start --enable amazon-ssm-agent' do
+  action :run
+  not_if 'ps aux | grep amazon-ssm-agent'
+end


### PR DESCRIPTION
For Ubuntu Amazon is releasing Snap packages for this now. These are also integrated in the AMIs, so even if one wants to use the deb package, this cookbook as is will not work.

I added an attribute switch to select package or snap and I remove the other, since they don't work together on one system.

This is tested working in both directions. If I have not observered any particular form in comments or such, feel free to say so and I'll correct that.