### PR TITLE
Support other architectures (aarch64, x86)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,6 +4,7 @@
 #
 # Copyright:: 2017, Sturdy Networks
 # Copyright:: 2017, Jonathan Serafini
+# Copyright:: 2020, Keith Gable
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -92,5 +92,5 @@ default['ssm_agent'].tap do |config|
 
   # Actions to set the agent to
   # @since 0.1.0
-  config['service']['actions'] = %w(enable start)
+  config['service']['actions'] = %w[enable start]
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Map the kernel machine to the architecture used by Amazon in URLs.
+# Windows gets a Linux-compatible machine type by Ohai/Chef.
+architecture = case node['kernel']['machine']
+               when 'aarch64'      then 'arm64'
+               when 'i386', 'i686' then '386'
+               when 'x86_64'       then 'amd64'
+               end
+
 default['ssm_agent'].tap do |config|
   config['install_method'] = node['platform'] == 'ubuntu' ? 'snap' : 'package'
 
@@ -39,11 +47,11 @@ default['ssm_agent'].tap do |config|
     'https://amazon-ssm-%s.s3.amazonaws.com/%s/%s/%s',
     config['region'],
     config['package']['version'],
-    value_for_platform_family('rhel' => 'linux_amd64',
-                              'suse' => 'linux_amd64',
-                              'amazon' => 'linux_amd64',
-                              'debian' => 'debian_amd64',
-                              'windows' => 'windows_amd64'),
+    value_for_platform_family('rhel' => "linux_#{architecture}",
+                              'suse' => "linux_#{architecture}",
+                              'amazon' => "linux_#{architecture}",
+                              'debian' => "debian_#{architecture}",
+                              'windows' => "windows_#{architecture}"),
     value_for_platform_family('rhel' => 'amazon-ssm-agent.rpm',
                               'suse' => 'amazon-ssm-agent.rpm',
                               'amazon' => 'amazon-ssm-agent.rpm',

--- a/attributes/ssm_agent-logrotate.rb
+++ b/attributes/ssm_agent-logrotate.rb
@@ -4,6 +4,7 @@
 #
 # Copyright:: 2017, Sturdy Networks
 # Copyright:: 2017, Jonathan Serafini
+# Copyright:: 2020, Keith Gable
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/attributes/ssm_agent-logrotate.rb
+++ b/attributes/ssm_agent-logrotate.rb
@@ -17,13 +17,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Save repeating the same node attribute
+service_name = node['ssm_agent']['service']['name']
+
 # Amazon SSM Agent logrotation
 # @since 0.1.0
 default['ssm_agent']['logrotate'].tap do |config|
   config['rotate'] = 7
   config['frequency'] = 'daily'
-  config['postrotate'] = format(
-    'service %s restart',
-    node['ssm_agent']['service']['name']
-  )
+
+  # Support systemd distros natively
+  config['postrotate'] = if node['init_package'] == 'systemd'
+                           "systemctl restart #{service_name}"
+                         else
+                           "service #{service_name} restart"
+                         end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ source_url 'https://github.com/sturdycloud/sturdy_ssm_agent-cookbook'
 version '2.1.0'
 
 chef_version '>= 12.1' if respond_to?(:chef_version)
-%w(amazon redhat debian ubuntu suse).each do |p|
+%w[amazon redhat debian ubuntu suse].each do |p|
   supports p
 end
 


### PR DESCRIPTION
The SSM agent can be installed on both ARM64 and x86 architectures for Linux and Windows, so this PR updates the cookbook to support them (well, not Windows, because your `supports` doesn't include Windows and I don't have a way to test, but theoretically it will work on 32-bit Windows).