### PR TITLE
Add support for CentOS.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -51,11 +51,13 @@ default['ssm_agent'].tap do |config|
     value_for_platform_family('rhel' => "linux_#{architecture}",
                               'suse' => "linux_#{architecture}",
                               'amazon' => "linux_#{architecture}",
+                              'centos' => "linux_#{architecture}",
                               'debian' => "debian_#{architecture}",
                               'windows' => "windows_#{architecture}"),
     value_for_platform_family('rhel' => 'amazon-ssm-agent.rpm',
                               'suse' => 'amazon-ssm-agent.rpm',
                               'amazon' => 'amazon-ssm-agent.rpm',
+                              'centos' => 'amazon-ssm-agent.rpm',
                               'debian' => 'amazon-ssm-agent.deb',
                               'windows' => 'AmazonSSMAgent.msi')
   )
@@ -67,6 +69,7 @@ default['ssm_agent'].tap do |config|
     value_for_platform_family('rhel' => 'amazon-ssm-agent.rpm',
                               'suse' => 'amazon-ssm-agent.rpm',
                               'amazon' => 'amazon-ssm-agent.rpm',
+                              'centos' => 'amazon-ssm-agent.rpm',
                               'debian' => 'amazon-ssm-agent.deb',
                               'windows' => 'AmazonSSMAgent.msi')
   )
@@ -93,5 +96,7 @@ default['ssm_agent'].tap do |config|
 
   # Actions to set the agent to
   # @since 0.1.0
-  config['service']['actions'] = %w[enable start]
+  if node['platform'] != 'centos'
+    config['service']['actions'] = %w[enable start]
+  end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,10 +6,10 @@ description 'Amazon EC2 Simple Systems Manager (SSM) agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/sturdycloud/sturdy_ssm_agent-cookbook/issues'
 source_url 'https://github.com/sturdycloud/sturdy_ssm_agent-cookbook'
-version '2.2.0'
+version '2.2.0-turbo'
 
 chef_version '>= 12.1' if respond_to?(:chef_version)
-%w[amazon redhat debian ubuntu suse].each do |p|
+%w[amazon redhat debian ubuntu suse ubuntu].each do |p|
   supports p
 end
 

--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -38,6 +38,7 @@ package 'amazon-ssm-agent' do # ~FC109
     'rhel' => Chef::Provider::Package::Yum,
     'suse' => Chef::Provider::Package::Zypper,
     'amazon' => Chef::Provider::Package::Yum,
+    'ubuntu' => Chef::Provider::Package::Yum,
     'debian' => Chef::Provider::Package::Dpkg,
     'windows' => Chef::Provider::Package::Windows
   )
@@ -47,6 +48,10 @@ end
 # Ensure service state
 # @since 0.1.0
 service node['ssm_agent']['service']['name'] do
-  provider Chef::Provider::Service::Upstart if node['platform'].include? 'amazon'
+  if node['platform'].include? 'centos'
+    provider Chef::Provider::Service::Init
+  elsif node['platform'].include? 'amazon'
+    provider Chef::Provider::Service::Upstart
+  end
   action node['ssm_agent']['service']['actions']
 end


### PR DESCRIPTION
This is CentOS 7 (in AWS, the hardened image https://aws.amazon.com/marketplace/pp/B07MJ75S6C) which uses the old (and reliable!) Init system.